### PR TITLE
Remove conflict with HHVM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16"
     },
-    "conflict": {
-        "hhvm": "*"
-    },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true


### PR DESCRIPTION
GitHub Actions' VMs include HHVM even if you not using it (among many other things), therefore having a conflict with HHVM [leads to a need to install](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5268) a package with `--ignore-platform-req=hhvm` to test with it on GitHub because Composer considers HHVM even if you run Composer itself with plain old PHP. I would understand if it would consider HHVM if you would be using it _with_ HHVM, but it isn't. (But on the other hand this makes sense since, IIRC, you can't run Composer with HHVM.)

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - php-cs-fixer/phpunit-constraint-xmlmatchesxsd v1.2.1 requires phpunitgoodpractices/polyfill ^1.4 -> satisfiable by phpunitgoodpractices/polyfill[v1.4.0].
    - php-cs-fixer/phpunit-constraint-xmlmatchesxsd v1.2.1 requires phpunitgoodpractices/polyfill ^1.4 -> satisfiable by phpunitgoodpractices/polyfill[v1.4.0].
    - phpunitgoodpractices/polyfill v1.4.0 conflicts with hhvm[99.999].
    - hhvm 99.999 conflicts with phpunitgoodpractices/polyfill[v1.4.0].
    - Installation request for hhvm 99.999 -> satisfiable by hhvm[99.999].
    - Installation request for php-cs-fixer/phpunit-constraint-xmlmatchesxsd ^1.2.1 -> satisfiable by php-cs-fixer/phpunit-constraint-xmlmatchesxsd[v1.2.1].
```

Which is all downright annoying. Who's actually using HHVM outside of Facebook these days?.. Even they are not.