### PR TITLE
Add more methods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
           vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
       - name: Upload coverage results to Coveralls
+        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,4 +61,10 @@ jobs:
 
       - name: Run tests
         run: |
-          vendor/bin/phpunit
+          vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          php vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /composer.lock
 /phpunit.xml
 /vendor/
+/build/

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,6 +22,7 @@ return PhpCsFixer\Config::create()
         'combine_consecutive_unsets' => true,
         'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
+        'declare_strict_types' => false,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,
         'explicit_string_variable' => true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2"
+        "friendsofphp/php-cs-fixer": "^2",
+        "php-coveralls/php-coveralls": "^2.4"
     },
     "config": {
         "optimize-autoloader": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./vendor/autoload.php">
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
     <testsuites>
         <testsuite name="Default">
             <directory>tests</directory>

--- a/src/PolyfillTrait.php
+++ b/src/PolyfillTrait.php
@@ -14,14 +14,7 @@ namespace PHPUnitGoodPractices\Polyfill;
 if (version_compare(\PHPUnit\Runner\Version::id(), '7.0.0') < 0) {
     trait PolyfillTrait
     {
-        public function expectException($exception)
-        {
-            if (\is_callable(['parent', 'expectException'])) {
-                parent::expectException($exception);
-            } else {
-                $this->setExpectedException($exception);
-            }
-        }
+        use PolyfillTrait6;
     }
 } else {
     trait PolyfillTrait

--- a/src/PolyfillTrait6.php
+++ b/src/PolyfillTrait6.php
@@ -29,10 +29,28 @@ trait PolyfillTrait6
     {
         if (\is_callable(['parent', 'expectExceptionMessageMatches'])) {
             parent::expectExceptionMessageMatches($regexp);
-        } elseif (\is_callable(['parent', 'setExpectedExceptionRegExp'])) {
-            $this->setExpectedExceptionRegExp(\Exception::class, $regexp);
-        } else {
+
+            return;
+        }
+
+        // In some PHPUnit versions just setting an expectation for specific
+        // expection message won't trigger exception handler. Therefore we need
+        // to set the expected type, but trying to keep the type.
+        if (\is_callable(['parent', 'getExpectedException'])) {
+            $expectedException = parent::getExpectedException(); // This is an @internal method.
+        }
+
+        if (null === $expectedException) {
+            $expectedException = \Exception::class;
+        }
+
+        $this->expectException($expectedException);
+
+        if (\is_callable(['parent', 'expectExceptionMessageRegExp'])) {
+            // Method available since Release 5.2.0
             $this->expectExceptionMessageRegExp($regexp);
+        } else {
+            $this->setExpectedExceptionRegExp($expectedException, $regexp);
         }
     }
 

--- a/src/PolyfillTrait6.php
+++ b/src/PolyfillTrait6.php
@@ -38,46 +38,82 @@ trait PolyfillTrait6
 
     public static function assertIsArray($actual, $message = '')
     {
-        static::assertInternalType('array', $actual, $message);
+        if (\is_callable(['parent', 'assertIsArray'])) {
+            parent::assertIsArray($actual, $message);
+        } else {
+            static::assertInternalType('array', $actual, $message);
+        }
     }
 
     public static function assertIsString($actual, $message = '')
     {
-        static::assertInternalType('string', $actual, $message);
+        if (\is_callable(['parent', 'assertIsString'])) {
+            parent::assertIsString($actual, $message);
+        } else {
+            static::assertInternalType('string', $actual, $message);
+        }
     }
 
     public static function assertIsBool($actual, $message = '')
     {
-        static::assertInternalType('bool', $actual, $message);
+        if (\is_callable(['parent', 'assertIsBool'])) {
+            parent::assertIsBool($actual, $message);
+        } else {
+            static::assertInternalType('bool', $actual, $message);
+        }
     }
 
     public static function assertIsCallable($actual, $message = '')
     {
-        static::assertInternalType('callable', $actual, $message);
+        if (\is_callable(['parent', 'assertIsCallable'])) {
+            parent::assertIsCallable($actual, $message);
+        } else {
+            static::assertInternalType('callable', $actual, $message);
+        }
     }
 
     public static function assertIsInt($actual, $message = '')
     {
-        static::assertInternalType('int', $actual, $message);
+        if (\is_callable(['parent', 'assertIsInt'])) {
+            parent::assertIsInt($actual, $message);
+        } else {
+            static::assertInternalType('int', $actual, $message);
+        }
     }
 
     public static function assertMatchesRegularExpression($pattern, $string, $message = '')
     {
-        static::assertRegExp($pattern, $string, $message);
+        if (\is_callable(['parent', 'assertMatchesRegularExpression'])) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            static::assertRegExp($pattern, $string, $message);
+        }
     }
 
     public static function assertStringContainsString($needle, $haystack, $message = '')
     {
-        static::assertContains($needle, $haystack, $message);
+        if (\is_callable(['parent', 'assertStringContainsString'])) {
+            parent::assertStringContainsString($needle, $haystack, $message);
+        } else {
+            static::assertContains($needle, $haystack, $message);
+        }
     }
 
     public static function assertStringNotContainsString($needle, $haystack, $message = '')
     {
-        static::assertNotContains($needle, $haystack, $message);
+        if (\is_callable(['parent', 'assertStringNotContainsString'])) {
+            parent::assertStringNotContainsString($needle, $haystack, $message);
+        } else {
+            static::assertNotContains($needle, $haystack, $message);
+        }
     }
 
     public static function assertFileDoesNotExist($filename, $message = '')
     {
-        static::assertFileNotExists($filename, $message);
+        if (\is_callable(['parent', 'assertFileDoesNotExist'])) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            static::assertFileNotExists($filename, $message);
+        }
     }
 }

--- a/src/PolyfillTrait6.php
+++ b/src/PolyfillTrait6.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of PHPUnit Good Practices.
+ *
+ * (c) Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PHPUnitGoodPractices\Polyfill;
+
+/**
+ * @internal
+ */
+trait PolyfillTrait6
+{
+    public function expectException($exception)
+    {
+        if (\is_callable(['parent', 'expectException'])) {
+            parent::expectException($exception);
+        } else {
+            $this->setExpectedException($exception);
+        }
+    }
+
+    public function expectExceptionMessageMatches($regexp)
+    {
+        if (\is_callable(['parent', 'expectExceptionMessageMatches'])) {
+            parent::expectExceptionMessageMatches($regexp);
+        } elseif (\is_callable(['parent', 'setExpectedExceptionRegExp'])) {
+            $this->setExpectedExceptionRegExp(\Exception::class, $regexp);
+        } else {
+            $this->expectExceptionMessageRegExp($regexp);
+        }
+    }
+
+    public static function assertIsArray($actual, $message = '')
+    {
+        static::assertInternalType('array', $actual, $message);
+    }
+
+    public static function assertIsString($actual, $message = '')
+    {
+        static::assertInternalType('string', $actual, $message);
+    }
+
+    public static function assertIsBool($actual, $message = '')
+    {
+        static::assertInternalType('bool', $actual, $message);
+    }
+
+    public static function assertIsCallable($actual, $message = '')
+    {
+        static::assertInternalType('callable', $actual, $message);
+    }
+
+    public static function assertIsInt($actual, $message = '')
+    {
+        static::assertInternalType('int', $actual, $message);
+    }
+
+    public static function assertMatchesRegularExpression($pattern, $string, $message = '')
+    {
+        static::assertRegExp($pattern, $string, $message);
+    }
+
+    public static function assertStringContainsString($needle, $haystack, $message = '')
+    {
+        static::assertContains($needle, $haystack, $message);
+    }
+
+    public static function assertStringNotContainsString($needle, $haystack, $message = '')
+    {
+        static::assertNotContains($needle, $haystack, $message);
+    }
+
+    public static function assertFileDoesNotExist($filename, $message = '')
+    {
+        static::assertFileNotExists($filename, $message);
+    }
+}

--- a/src/PolyfillTrait7.php
+++ b/src/PolyfillTrait7.php
@@ -26,4 +26,31 @@ trait PolyfillTrait7
             $this->setExpectedException($exception);
         }
     }
+
+    public function expectExceptionMessageMatches(string $regexp): void
+    {
+        if (\is_callable(['parent', 'expectExceptionMessageMatches'])) {
+            parent::expectExceptionMessageMatches($regexp);
+        } else {
+            $this->expectExceptionMessageRegExp($regexp);
+        }
+    }
+
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (\is_callable(['parent', 'assertMatchesRegularExpression'])) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            static::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        if (\is_callable(['parent', 'assertFileDoesNotExist'])) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            static::assertFileNotExists($filename, $message);
+        }
+    }
 }

--- a/tests/PolyfillTest.php
+++ b/tests/PolyfillTest.php
@@ -25,4 +25,57 @@ class PolyfillTest extends TestCase
         throw new \RuntimeException();
         $this->fail();
     }
+
+    public function testExpectExceptionMessageMatches()
+    {
+        $this->expectExceptionMessageMatches('/example/');
+
+        throw new \RuntimeException('example');
+        $this->fail();
+    }
+
+    public function testAssertIsArray()
+    {
+        $this->assertIsArray([]);
+    }
+
+    public function testAssertIsString()
+    {
+        $this->assertIsString('');
+    }
+
+    public function testAssertIsBool()
+    {
+        $this->assertIsBool(true);
+    }
+
+    public function testAssertIsCallable()
+    {
+        $this->assertIsCallable([$this, 'testAssertIsCallable']);
+    }
+
+    public function testAssertIsInt()
+    {
+        $this->assertIsInt(1);
+    }
+
+    public function testAssertMatchesRegularExpression()
+    {
+        $this->assertMatchesRegularExpression('/\d/', '123');
+    }
+
+    public function testAssertStringContainsString()
+    {
+        $this->assertStringContainsString('test', 'testing');
+    }
+
+    public function testAssertStringNotContainsString()
+    {
+        $this->assertStringNotContainsString('foobar', 'testing');
+    }
+
+    public function testAssertFileDoesNotExist()
+    {
+        $this->assertFileDoesNotExist('invalid');
+    }
 }

--- a/tests/PolyfillTest.php
+++ b/tests/PolyfillTest.php
@@ -23,7 +23,6 @@ class PolyfillTest extends TestCase
         $this->expectException(\RuntimeException::class);
 
         throw new \RuntimeException();
-        $this->fail();
     }
 
     public function testExpectExceptionMessageMatches()
@@ -31,7 +30,6 @@ class PolyfillTest extends TestCase
         $this->expectExceptionMessageMatches('/example/');
 
         throw new \RuntimeException('example');
-        $this->fail();
     }
 
     public function testAssertIsArray()


### PR DESCRIPTION
This should be enough to get https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5269 working.

 - [x] `@method        expectExceptionMessageMatches($regexp)`
 - [x] `@method static assertIsArray($actual, $message = '')`
 - [x]  `@method static assertIsString($actual, $message = '')`
 - [x]  `@method static assertMatchesRegularExpression($pattern, $string, $message = '')`
 - [x]  `@method static assertFileDoesNotExist($filename, $message = '')`
 - [x]  `@method static assertIsBool($actual, $message = '')`
 - [x]  `@method static assertIsCallable($actual, $message = '')`
 - [x]  `@method static assertIsInt($actual, $message = '')`
 - [x]  `@method static assertStringContainsString($needle, $haystack, $message = '')`
 - [x]  `@method static assertStringNotContainsString($needle, $haystack, $message = '')`
